### PR TITLE
feature/create edit and archive the client external and bug fix

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,12 +18,11 @@ generator client {
 
 datasource db {
   provider  = "postgresql"
-  url       = env("DATABASE_URL_PROD")
-  directUrl = env("DIRECT_URL_PROD")
-  //url       = env("DATABASE_URL")
-  //directUrl = env("DATABASE_URL")
+  // url       = env("DATABASE_URL_PROD")
+  // directUrl = env("DIRECT_URL_PROD")
+  url       = env("DATABASE_URL")
+  directUrl = env("DATABASE_URL")
 }
-
 enum user_type {
   admin
   client
@@ -51,7 +50,6 @@ enum work_day {
   saturday
   sunday
 }
-
 enum service_type {
   case
   consultation
@@ -174,21 +172,20 @@ model LawyerDetails {
   biography      String /// Biografía del abogado
   linkedin       String /// URL del perfil de LinkedIn
 
-  user          Users          @relation(fields: [lawyer_id], references: [id], onDelete: Cascade)
-  lawyerService LawyerService? /// Relación uno a uno: Servicio del abogado
-  events        Events[] /// Relación uno a muchos: Eventos asociados a este abogado
+  user                 Users                  @relation(fields: [lawyer_id], references: [id], onDelete: Cascade)
+  lawyerService        LawyerService? /// Relación uno a uno: Servicio del abogado
+  events               Events[] /// Relación uno a muchos: Eventos asociados a este abogado
 
   @@map("lawyer_details")
 }
 
 model ClientDetails {
-  client_id     Int     @id /// Identificador (igual al id del usuario)
-  occupation    String? /// Ocupación del cliente
-  age_range     String? /// Rango de edad del cliente
-  budget        Float? /// Presupuesto disponible del cliente
-  urgency_level String? /// Nivel de urgencia de la necesidad legal
+  client_id        Int     @id /// Identificador (igual al id del usuario)
+  budget_range     String? /// Rango presupuestario para contratar el servicio legal
+  urgency_level    String? /// Nivel de urgencia o prioridad de la necesidad legal
+  requirement_type String? /// Tipo de asistencia legal requerida
 
-  user Users @relation(fields: [client_id], references: [id], onDelete: Cascade)
+  user                 Users                  @relation(fields: [client_id], references: [id], onDelete: Cascade)
 
   @@map("client_details")
 }
@@ -209,24 +206,23 @@ model UserDetails {
 
   articles Articles[] /// Relación uno a muchos: Artículos asociados a este UserDetails
 
-  user               Users             @relation(fields: [user_id], references: [id], onDelete: Cascade)
-  Preference         Preference?
-  Locations          Locations?
-  communityUsers     CommunityUsers[] /// Relación uno a muchos: Membresías en comunidades asociadas a este UserDetails
-  external_clients   ExternalClients[] /// Clientes externos registrados por este usuario
-  services_as_lawyer Services[]        @relation("LawyerServices") /// Servicios en los que actúa como abogado
-  services_as_client Services[]        @relation("ClientServices") /// Servicios en los que actúa como cliente
+  user           Users            @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  Preference     Preference?
+  Locations      Locations?
+  communityUsers CommunityUsers[] /// Relación uno a muchos: Membresías en comunidades asociadas a este UserDetails
+  external_clients    ExternalClients[] /// Clientes externos registrados por este usuario
+  services_as_lawyer  Services[]        @relation("LawyerServices") /// Servicios en los que actúa como abogado
+  services_as_client  Services[]        @relation("ClientServices") /// Servicios en los que actúa como cliente
 
   @@map("user_details")
 }
 
 model Preference {
-  id                       Int     @id @default(autoincrement()) /// Identificador único de la preferencia
-  user_id                  Int     @unique /// Identificador del UserDetails
-  communication_channel    String? /// Medio preferido de comunicación del usuario
-  receive_notifications    Boolean @default(true) /// Indica si se desean recibir notificaciones
-  notification_channels    String? /// Canales para recibir notificaciones (Email, SMS o dentro de la plataforma)
-  communication_preference String? /// Preferencia de comunicación del cliente
+  id                    Int     @id @default(autoincrement()) /// Identificador único de la preferencia
+  user_id               Int     @unique /// Identificador del UserDetails
+  communication_channel String? /// Medio preferido de comunicación del usuario
+  receive_notifications Boolean /// Indica si se desean recibir notificaciones
+  notification_channels String? /// Canales para recibir notificaciones (Email, SMS o dentro de la plataforma)
 
   userDetails UserDetails @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
 
@@ -236,9 +232,13 @@ model Preference {
 model Locations {
   id           Int     @id @default(autoincrement()) /// Identificador único de la ubicación
   user_id      Int     @unique /// Identificador del UserDetails
-  full_address String? @db.VarChar(255) /// Dirección completa
+  country      String  @db.VarChar(100) /// País de la ubicación
+  state        String  @db.VarChar(100) /// Área administrativa principal (estado, región, provincia)
+  city         String  @db.VarChar(100) /// Ciudad o municipio
   latitude     Float /// Latitud
   longitude    Float /// Longitud
+  full_address String? @db.VarChar(255) /// Dirección completa (opcional)
+  postal_code  String? @db.VarChar(20) /// Código postal (opcional)
 
   userDetails UserDetails @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
 
@@ -246,12 +246,10 @@ model Locations {
 }
 
 model Articles {
-  id                    String         @id @default(uuid()) /// Identificador único del artículo
+  id                    Int            @id @default(autoincrement()) /// Identificador único del artículo
   user_id               Int /// Identificador del autor (UserDetails)
   title                 String /// Título del artículo
   content               String /// Contenido del artículo
-  resume                String? /// Resumen del artículo
-  reading_time          Int /// Tiempo de lectura estimado en minutos
   banner                String? /// Banner del artículo
   category_id           Int /// Identificador de la categoría
   publication_timestamp DateTime /// Fecha de publicación
@@ -444,82 +442,83 @@ model Reactions {
 }
 
 model Events {
-  id          Int      @id @default(autoincrement()) /// Identificador del evento
-  lawyer_id   Int /// Abogado asociado
-  title       String /// Título del evento
-  description String? /// Descripción
-  start_time  DateTime @db.Time /// Hora de inicio (común para todas las fechas)
-  end_time    DateTime @db.Time /// Hora de fin (común para todas las fechas)
+  id           Int       @id @default(autoincrement()) /// Identificador del evento
+  lawyer_id    Int       /// Abogado asociado
+  title        String    /// Título del evento
+  description  String?   /// Descripción
+  start_time   DateTime  @db.Time /// Hora de inicio (común para todas las fechas)
+  end_time     DateTime  @db.Time /// Hora de fin (común para todas las fechas)
 
-  lawyer LawyerDetails @relation(fields: [lawyer_id], references: [lawyer_id], onDelete: Cascade)
-  dates  EventDates[] /// Fechas específicas del evento
+  lawyer       LawyerDetails @relation(fields: [lawyer_id], references: [lawyer_id], onDelete: Cascade)
+  dates        EventDates[] /// Fechas específicas del evento
 
   @@map("events")
 }
 
 model EventDates {
-  id       Int      @id @default(autoincrement()) /// ID único
-  event_id Int /// Evento asociado
-  date     DateTime @db.Date /// Fecha específica del evento
+  id        Int      @id @default(autoincrement()) /// ID único
+  event_id  Int      /// Evento asociado
+  date      DateTime @db.Date /// Fecha específica del evento
 
-  event Events @relation(fields: [event_id], references: [id], onDelete: Cascade)
+  event     Events   @relation(fields: [event_id], references: [id], onDelete: Cascade)
 
   @@unique([event_id, date]) // Evita duplicados
   @@map("event_dates")
 }
 
 model ExternalClients {
-  id             Int      @id @default(autoincrement()) /// Identificador único del cliente externo
-  user_detail_id Int /// Usuario que registró al cliente externo
-  full_name      String /// Nombre completo del cliente externo
-  email          String?  @default("") /// Correo electrónico del cliente externo
-  phone          String /// Teléfono del cliente externo
-  dni            String /// Documento de identidad del cliente externo
-  created_at     DateTime @default(now()) /// Fecha de registro del cliente externo
+  id              Int           @id @default(autoincrement())   /// PK
+  user_detail_id  Int                                       /// Abogado que creó este cliente
+  full_name       String                                    /// Nombre completo
+  email           String?       @default("")                 /// Correo opcional
+  phone           String                                    /// Teléfono
+  dni             String                                    /// DNI
+  created_at      DateTime      @default(now())              /// Fecha de creación
+  archived        Boolean       @default(false)               /// Soft-delete flag
 
-  user_detail UserDetails @relation(fields: [user_detail_id], references: [user_id], onDelete: Cascade)
-  services    Services[] /// Servicios asociados a este cliente externo
+  user_detail     UserDetails   @relation(fields: [user_detail_id], references: [user_id], onDelete: Cascade)
+  services        Services[]                                /// Casos/consultas asociados
 
   @@map("external_clients")
 }
 
 model Services {
-  id                 Int          @id @default(autoincrement()) /// Identificador único del servicio
-  type               service_type /// Tipo de servicio (consulta, caso, etc.)
-  created_at         DateTime     @default(now()) /// Fecha de creación del servicio
+  id                 Int      @id @default(autoincrement()) /// Identificador único del servicio
+  type               service_type  /// Tipo de servicio (consulta, caso, etc.)
+  created_at         DateTime @default(now()) /// Fecha de creación del servicio
   lawyer_id          Int? /// ID del abogado que atiende el servicio
   client_id          Int? /// ID del cliente registrado
   external_client_id Int? /// ID del cliente externo (opcional)
 
-  lawyer          UserDetails?     @relation("LawyerServices", fields: [lawyer_id], references: [user_id])
-  client          UserDetails?     @relation("ClientServices", fields: [client_id], references: [user_id])
-  external_client ExternalClients? @relation(fields: [external_client_id], references: [id])
+  lawyer             UserDetails? @relation("LawyerServices", fields: [lawyer_id], references: [user_id])
+  client             UserDetails? @relation("ClientServices", fields: [client_id], references: [user_id])
+  external_client    ExternalClients? @relation(fields: [external_client_id], references: [id])
 
-  cases         Cases[] /// Casos asociados a este servicio
-  consultations Consultations[] /// Consultas asociadas a este servicio
-  calls         Calls[] /// Llamadas asociadas
-  messages      Messages[] /// Mensajes entre abogado y cliente
-  attachments   Attachments[] /// Archivos compartidos
+  cases              Cases[] /// Casos asociados a este servicio
+  consultations      Consultations[] /// Consultas asociadas a este servicio
+  calls              Calls[] /// Llamadas asociadas
+  messages           Messages[] /// Mensajes entre abogado y cliente
+  attachments        Attachments[] /// Archivos compartidos
 
   @@map("services")
 }
 
 model CaseCategories {
   id          Int     @id @default(autoincrement()) /// Identificador único de la categoría de caso
-  name        String  @unique /// Nombre de la categoría
+  name        String  @unique/// Nombre de la categoría
   description String? /// Descripción detallada de la categoría
 
-  cases Cases[] /// Casos que pertenecen a esta categoría
+  cases       Cases[] /// Casos que pertenecen a esta categoría
 
   @@map("case_categories")
 }
 
 model CaseStatuses {
   id          Int     @id @default(autoincrement()) /// Identificador único del estado del caso
-  name        String  @unique /// Nombre del estado
+  name        String  @unique/// Nombre del estado
   description String? /// Descripción del estado
 
-  cases Cases[] /// Casos que tienen este estado
+  cases       Cases[] /// Casos que tienen este estado
 
   @@map("case_statuses")
 }
@@ -532,15 +531,15 @@ model Cases {
   category_id    Int /// ID de la categoría asignada
   urgency        case_urgency /// Nivel de urgencia del caso
   status_id      Int /// ID del estado actual del caso
-  is_public      Boolean
-  reference_code String       @default(cuid()) /// Numero de expediente
-  created_at     DateTime     @default(now()) /// Fecha de creación del caso
-  archived       Boolean      @default(false)
+  is_public      Boolean 
+  reference_code String @default(cuid()) /// Numero de expediente
+  created_at     DateTime @default(now()) /// Fecha de creación del caso
+  archived       Boolean @default(false) 
 
-  service   Services        @relation(fields: [service_id], references: [id], onDelete: Cascade)
-  category  CaseCategories  @relation(fields: [category_id], references: [id])
-  status    CaseStatuses    @relation(fields: [status_id], references: [id])
-  histories CaseHistories[] /// Historial de cambios del caso
+  service        Services       @relation(fields: [service_id], references: [id], onDelete: Cascade)
+  category       CaseCategories @relation(fields: [category_id], references: [id])
+  status         CaseStatuses   @relation(fields: [status_id], references: [id])
+  histories      CaseHistories[] /// Historial de cambios del caso
 
   @@map("cases")
 }
@@ -548,42 +547,42 @@ model Cases {
 model CaseHistories {
   id         Int      @id @default(autoincrement()) /// Identificador único del historial
   case_id    Int /// ID del caso asociado
-  changed_by Int ///Saber quien hizo el cambio
-  field      String   @db.VarChar(60) ///Saber que campo fue cambiado (estado, archivado o documentado)  
+  changed_by Int  ///Saber quien hizo el cambio
+  field      String   @db.VarChar(60)    ///Saber que campo fue cambiado (estado, archivado o documentado)  
   old_value  String /// Valor anterior antes del cambio
   new_value  String /// Nuevo valor asignado
   note       String? /// Comentario adicional
   created_at DateTime @default(now()) /// Fecha del cambio
 
-  case Cases @relation(fields: [case_id], references: [id])
+  case       Cases @relation(fields: [case_id], references: [id])
 
   @@map("case_histories")
 }
 
 model Consultations {
-  id            Int                   @id @default(autoincrement()) /// Identificador único de la consulta
-  service_id    Int /// ID del servicio asociado
-  topic         String /// Tema principal de la consulta
-  question      String /// Pregunta detallada del cliente
-  response      String? /// Respuesta del abogado (opcional)
-  status        consultation_status /// Estado actual de la consulta
-  created_at    DateTime              @default(now()) /// Fecha de creación
-  answered_at   DateTime? /// Fecha en que fue respondida (opcional)
-  rating        Int? /// Calificación del cliente (1 a 5, opcional)
-  priority      consultation_priority /// Prioridad asignada
-  confidential  Boolean /// Si es confidencial
-  requires_call Boolean /// Si necesita llamada
+  id             Int                  @id @default(autoincrement()) /// Identificador único de la consulta
+  service_id     Int /// ID del servicio asociado
+  topic          String /// Tema principal de la consulta
+  question       String /// Pregunta detallada del cliente
+  response       String? /// Respuesta del abogado (opcional)
+  status         consultation_status /// Estado actual de la consulta
+  created_at     DateTime @default(now()) /// Fecha de creación
+  answered_at    DateTime? /// Fecha en que fue respondida (opcional)
+  rating         Int? /// Calificación del cliente (1 a 5, opcional)
+  priority       consultation_priority /// Prioridad asignada
+  confidential   Boolean /// Si es confidencial
+  requires_call  Boolean /// Si necesita llamada
 
-  service Services @relation(fields: [service_id], references: [id], onDelete: Cascade)
+  service        Services @relation(fields: [service_id], references: [id], onDelete: Cascade)
 
   @@map("consultations")
 }
 
 model CallCategories {
-  id   Int    @id @default(autoincrement()) /// Identificador único de la categoría de llamada
-  name String /// Nombre de la categoría
+  id     Int     @id @default(autoincrement()) /// Identificador único de la categoría de llamada
+  name   String /// Nombre de la categoría
 
-  calls Calls[] /// Llamadas asociadas
+  calls  Calls[] /// Llamadas asociadas
 
   @@map("call_categories")
 }
@@ -599,49 +598,49 @@ model Calls {
   notes            String? /// Notas adicionales
   category_id      Int /// ID de la categoría
   service_id       Int /// ID del servicio relacionado
-  created_at       DateTime    @default(now()) /// Fecha de creación
+  created_at       DateTime @default(now()) /// Fecha de creación
 
-  category CallCategories @relation(fields: [category_id], references: [id])
-  service  Services       @relation(fields: [service_id], references: [id], onDelete: Cascade)
+  category         CallCategories @relation(fields: [category_id], references: [id])
+  service          Services       @relation(fields: [service_id], references: [id], onDelete: Cascade)
 
   @@map("calls")
 }
 
 model Messages {
-  id         Int        @id @default(autoincrement()) /// Identificador único del mensaje
-  service_id Int /// ID del servicio asociado
-  content    String /// Contenido del mensaje
-  sent_by    actor_type /// Emisor: lawyer o client
-  is_read    Boolean /// Si fue leído
-  created_at DateTime   @default(now()) /// Fecha de envío
+  id          Int        @id @default(autoincrement()) /// Identificador único del mensaje
+  service_id  Int /// ID del servicio asociado
+  content     String /// Contenido del mensaje
+  sent_by     actor_type /// Emisor: lawyer o client
+  is_read     Boolean /// Si fue leído
+  created_at  DateTime   @default(now()) /// Fecha de envío
 
-  service Services @relation(fields: [service_id], references: [id], onDelete: Cascade)
+  service     Services   @relation(fields: [service_id], references: [id], onDelete: Cascade)
 
   @@map("messages")
 }
 
 model AttachmentCategories {
-  id   Int    @id @default(autoincrement()) /// Identificador único de la categoría
-  name String @unique /// Nombre de la categoría
+  id           Int     @id @default(autoincrement()) /// Identificador único de la categoría
+  name         String @unique/// Nombre de la categoría
 
-  attachments Attachments[] /// Archivos asociados
+  attachments  Attachments[] /// Archivos asociados
 
   @@map("attachment_categories")
 }
 
 model Attachments {
-  id          Int        @id @default(autoincrement()) /// Identificador único del archivo
-  file_key    String /// ruta/key en S3
-  label       String /// Nombre o etiqueta del archivo
-  description String? /// Descripción adicional
-  category_id Int /// ID de la categoría del archivo
-  uploaded_by actor_type /// Emisor del archivo: lawyer o client
-  created_at  DateTime   @default(now()) /// Fecha de subida
-  service_id  Int /// Servicio al que pertenece
-  archived    Boolean    @default(false)
+  id              Int        @id @default(autoincrement()) /// Identificador único del archivo
+  file_key        String       /// ruta/key en S3
+  label           String /// Nombre o etiqueta del archivo
+  description     String? /// Descripción adicional
+  category_id     Int /// ID de la categoría del archivo
+  uploaded_by     actor_type /// Emisor del archivo: lawyer o client
+  created_at      DateTime   @default(now()) /// Fecha de subida
+  service_id      Int /// Servicio al que pertenece
+  archived        Boolean  @default(false)
 
-  service  Services             @relation(fields: [service_id], references: [id], onDelete: Cascade)
-  category AttachmentCategories @relation(fields: [category_id], references: [id])
+  service         Services            @relation(fields: [service_id], references: [id], onDelete: Cascade)
+  category        AttachmentCategories @relation(fields: [category_id], references: [id])
 
   @@map("attachments")
 }

--- a/src/modules/case/domain/dtos/create_case_attachment.dto.ts
+++ b/src/modules/case/domain/dtos/create_case_attachment.dto.ts
@@ -2,9 +2,9 @@
 import { z } from "zod";
 
 export const CreateCaseAttachmentDto = z.object({
-  file_key:    z.string().min(5),
-  label:       z.string(),
-  description: z.string().optional(),
-  category_id: z.number().int().positive(),
+    file_key:    z.string().min(5).max(255),
+    label:       z.string().min(1).max(100),
+    description: z.string().max(500).optional(),
+    category_id: z.number().int().positive(),
 });
 export type CreateCaseAttachmentDtoType = z.infer<typeof CreateCaseAttachmentDto>;

--- a/src/modules/case/domain/dtos/index.ts
+++ b/src/modules/case/domain/dtos/index.ts
@@ -1,22 +1,21 @@
 // src/modules/case/domain/dtos/index.ts
-/* -----------------------------  Zod Schemas  ----------------------------- */
 
+/* -----------------------------  Zod Schemas  ----------------------------- */
 export { CreateCaseDto               as CreateCaseSchema }              from "./create_case.dto";
 export { UpdateCaseDto               as UpdateCaseSchema }              from "./update_case.dto";
 export { ChangeCaseStatusDto         as ChangeCaseStatusSchema }        from "./change_status_case.dto";
 export { CreateCaseAttachmentDto     as CreateCaseAttachmentSchema }    from "./create_case_attachment.dto";
-export { CreateExternalClientDto     as CreateExternalClientSchema }    from "./create_external_client.dto";
 export { CreateCaseMessageDto        as CreateCaseMessageSchema }       from "./create_case_message.dto";
-
 export { CreateConsultationDto       as CreateConsultationSchema }      from "./create_consultation.dto";
+export { CreateExternalClientDto     as CreateExternalClientSchema }    from "./create_external_client.dto";
+export { UpdateExternalClientSchema }                               from "./update_external_client.dto";
 
 /* -------------------------------  Types  --------------------------------- */
-
 export type { CreateCaseDtoType              as CreateCaseDto }              from "./create_case.dto";
 export type { UpdateCaseDtoType              as UpdateCaseDto }              from "./update_case.dto";
 export type { ChangeCaseStatusDtoType        as ChangeCaseStatusDto }        from "./change_status_case.dto";
 export type { CreateCaseAttachmentDtoType    as CreateCaseAttachmentDto }    from "./create_case_attachment.dto";
-export type { CreateExternalClientDtoType    as CreateExternalClientDto }    from "./create_external_client.dto";
 export type { CreateCaseMessageDtoType       as CreateCaseMessageDto }       from "./create_case_message.dto";
-
 export type { CreateConsultationDtoType      as CreateConsultationDto }      from "./create_consultation.dto";
+export type { CreateExternalClientDtoType    as CreateExternalClientDto }    from "./create_external_client.dto";
+export type { UpdateExternalClientDtoType    as UpdateExternalClientDto }    from "./update_external_client.dto";

--- a/src/modules/case/domain/dtos/update_external_client.dto.ts
+++ b/src/modules/case/domain/dtos/update_external_client.dto.ts
@@ -1,0 +1,11 @@
+// src/modules/case/domain/dtos/update_external_client.dto.ts
+import { z } from "zod";
+
+export const UpdateExternalClientSchema = z.object({
+  full_name: z.string().min(3).max(100).optional(),
+  phone:     z.string().min(6).optional(),
+  dni:       z.string().min(4).optional(),
+  email:     z.string().email().optional(),
+});
+
+export type UpdateExternalClientDtoType = z.infer<typeof UpdateExternalClientSchema>;

--- a/src/modules/case/domain/entities/external_client.entity.ts
+++ b/src/modules/case/domain/entities/external_client.entity.ts
@@ -3,8 +3,9 @@ export interface ExternalClientEntity {
   id: number;
   user_detail_id: number;
   full_name: string;
-  email?: string;
-  phone?: string;
-  dni?: string;
-  created_at?: Date;
+  email: string | null;
+  phone: string;
+  dni: string;
+  created_at: Date;
+  archived: boolean;
 }

--- a/src/modules/case/presentation/controllers/case.controller.ts
+++ b/src/modules/case/presentation/controllers/case.controller.ts
@@ -12,6 +12,7 @@ import {
   ChangeCaseStatusSchema,
   CreateCaseAttachmentSchema,
   CreateExternalClientSchema,
+  UpdateExternalClientSchema,
   CreateCaseMessageSchema,
 } from "../../domain/dtos/index";
 
@@ -35,12 +36,12 @@ const casesService = new CasesService(
 );
 
 casesService.init().catch(console.error);
-/* ─────────────── Helper user ─────────────── */
+
 type CurrentUser = { id: number; role: "client" | "lawyer" };
 const getUser = (req: Request): CurrentUser => (req as any).user as CurrentUser;
 
 export class CaseController {
-  /* ---------- POST /case ---------- */
+  /* ───────────── POST /case  ───────────── */
   async createCase(req: Request, res: Response): Promise<Response> {
     try {
       const dto = CreateCaseSchema.parse(req.body);
@@ -65,8 +66,7 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-
-  /* ---------- GET /case/explore ---------- */
+  /* ───────────── GET /case/explore ───────────── */
   async exploreCases(req: Request, res: Response): Promise<Response> {
     try {
       const QuerySchema = z.object({
@@ -77,7 +77,7 @@ export class CaseController {
       const { category_id, status_id } = QuerySchema.parse(req.query);
 
       const filters = {
-        is_public: true, 
+        is_public: true,
         ...(category_id && { category_id }),
         ...(status_id && { status_id }),
       };
@@ -97,8 +97,7 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-
-  /* ---------- GET /case/my ---------- */
+  /* ───────────── GET /case/my ───────────── */
   async getMyCases(req: Request, res: Response): Promise<Response> {
     try {
       const data = await casesService.getMyCases(getUser(req));
@@ -112,8 +111,7 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-
-  /* ---------- GET /case/:id ---------- */
+  /* ───────────── GET /case/:id───────────── */
   async getCaseById(req: Request, res: Response): Promise<Response> {
     try {
       const id = Number(req.params.id);
@@ -138,8 +136,7 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-
-  /* ---------- PUT /case/:id ---------- */
+  /* ───────────── PUT /case/:id ───────────── */
   async updateCase(req: Request, res: Response): Promise<Response> {
     try {
       const id = Number(req.params.id);
@@ -165,7 +162,7 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-  /* ---------- PATCH /case/:id/status ---------- */
+  /* ───────────── PATCH /case/:id/status───────────── */
   async changeStatus(req: Request, res: Response): Promise<Response> {
     try {
       const id = Number(req.params.id);
@@ -191,8 +188,7 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-
-  /* ---------- PATCH /case/:id/archive ---------- */
+  /* ───────────── PATCH /case/:id/archive───────────── */
   async archiveCase(req: Request, res: Response): Promise<Response> {
     try {
       const id = Number(req.params.id);
@@ -212,88 +208,110 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
+  /* ───────────── GET /cases/closed───────────── */
+  async getClosedCases(req: Request, res: Response) {
+    const data = await casesService.listClosedCases(getUser(req));
+    return res.json(buildHttpResponse(200, "Closed cases", req.path, data));
+  }
+  /* ───────────── GET /cases/archived──────────── */
+  async getArchivedCases(req: Request, res: Response) {
+    const data = await casesService.listArchivedCases(getUser(req));
+    return res.json(buildHttpResponse(200, "Archived cases", req.path, data));
+  }
+  /* ───────────── PATCH /cases/:id/reopen──────────── */
+  async reopenCase(req: Request, res: Response) {
+    const id = Number(req.params.id);
+    const data = await casesService.reopenCase(id, getUser(req));
+    return res.json(buildHttpResponse(200, "Case reopened", req.path, data));
+  }
+  /* ───────────── POST /case/:id/attachment─────────── */
+   async addAttachment(req: Request, res: Response): Promise<Response> {
+    // 0) Logs iniciales
+    console.log("▶️ [RAW BODY]   :", req.body);
+    console.log("▶️ [RAW FILES]  :", req.files);
 
-  /* ---------- POST /case/:id/attachment ---------- */
-  async addAttachment(req: Request, res: Response): Promise<Response> {
     try {
       const caseId = Number(req.params.id);
-      const user = getUser(req);
+      const user   = getUser(req);
 
-      const found = await casesService.getCaseById(caseId, user);
+      // 1) Validar caso y permisos
+      await casesService.getCaseById(caseId, user);
 
+      // 2) Validar archivo
       const files = req.files as { file: Express.Multer.File[] };
-      const file = files.file?.[0];
-      if (!file) {
-        throw new AppError("File missing", HttpStatusCodes.BAD_REQUEST.code);
+      const file  = files.file?.[0];
+      if (!file) throw new AppError("File missing", HttpStatusCodes.BAD_REQUEST.code);
+      if (file.size > 10 * 1024 * 1024) {
+        throw new AppError("El archivo supera el tamaño máximo de 10MB.", HttpStatusCodes.BAD_REQUEST.code);
       }
 
-      const MAX_FILE_SIZE = 10 * 1024 * 1024;
-      if (file.size > MAX_FILE_SIZE) {
-        throw new AppError(
-          "El archivo supera el tamaño máximo de 10MB.",
-          HttpStatusCodes.BAD_REQUEST.code
-        );
-      }
-
+      // 3) Subir a S3
       const { key: s3Key } = await uploadFile(file, `private/cases/${caseId}`);
 
-      const body = {
-        service_id: found.service_id,
-        file_key: s3Key,
-        label: req.body.label,
-        description: req.body.description,
-        category_id: Number(req.body.category_id),
+      // 4) Construir sólo lo que Zod espera (sin service_id)
+      const cleanBody = {
+        file_key:    s3Key,
+        label:       String(req.body.label).trim(),
+        description: req.body.description ? String(req.body.description).trim() : undefined,
+        category_id: Number(req.body.category_id.trim()),
       };
-      console.log("ATTACH BODY:", body);
-      const dto = CreateCaseAttachmentSchema.parse(body);
+      console.log("▶️ [CLEAN BODY] :", cleanBody);
 
+      // 5) Validar con Zod
+      const dto = CreateCaseAttachmentSchema.parse(cleanBody);
+
+      // 6) Llamar al servicio
       const created = await casesService.addAttachment(caseId, dto, user);
 
+      // 7) Responder
       return res
         .status(HttpStatusCodes.CREATED.code)
-        .json(
-          buildHttpResponse(
-            HttpStatusCodes.CREATED.code,
-            MESSAGES.CASE.ATTACHMENT_ADDED,
-            req.path,
-            created
-          )
-        );
-    } catch (error) {
+        .json({
+          status:      HttpStatusCodes.CREATED.code,
+          message:     MESSAGES.CASE.ATTACHMENT_ADDED,
+          path:        req.path,
+          timestamp:   new Date().toISOString(),
+          data:        created,
+        });
+    } 
+    catch (error) {
+      // Log completo del error para ver stack / issues
+      console.error("🚨 addAttachment ERROR:", error);
+
       if (error instanceof ZodError) {
-        const err = handleZodError(error, req);
-        return res.status(err.status).json(err);
+        const z = handleZodError(error, req);
+        return res.status(z.status).json(z);
       }
       return handleServerError(res, req, error);
     }
   }
-  /* ---------- GET /case/:id/attachment ---------- */
+
+  /* ───────────── GET /case/:id/attachment─────────── */
+
   async listAttachments(req: Request, res: Response): Promise<Response> {
-  try {
-    const caseId = Number(req.params.id);
-    const user   = getUser(req);
+    try {
+      const caseId = Number(req.params.id);
+      const user = getUser(req);
 
-    // 1) Validar permisos y obtener el case
-    await casesService.getCaseById(caseId, user);
+      await casesService.getCaseById(caseId, user);
 
-    // 2) Obtener lista de attachments con signed-URL
-    const list = await casesService.listAttachments(caseId, user);
+      const list = await casesService.listAttachments(caseId, user);
 
-    return res
-      .status(HttpStatusCodes.OK.code)
-      .json(
-        buildHttpResponse(
-          HttpStatusCodes.OK.code,
-          "Attachments fetched successfully",
-          req.path,
-          list
-        )
-      );
-  } catch (err) {
-    return handleServerError(res, req, err);
+      return res
+        .status(HttpStatusCodes.OK.code)
+        .json(
+          buildHttpResponse(
+            HttpStatusCodes.OK.code,
+            "Attachments fetched successfully",
+            req.path,
+            list
+          )
+        );
+    } catch (err) {
+      return handleServerError(res, req, err);
+    }
   }
-}
-  /* ---------- GET /case/:id/attachment/:attId ---------- */
+  /* ───────────── GET /case/:id/attachment/:attId───────────── */
   async getAttachmentUrl(req: Request, res: Response) {
     try {
       const caseId = Number(req.params.id);
@@ -316,53 +334,32 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-  /* ---------- ARCHIVED /case/:id/attachment/:attId ---------- */
-  async archiveAttachment(req: Request, res: Response): Promise<Response> {
-    try {
-      const attId = Number(req.params.attId);
-      await casesService.archiveAttachment(attId, getUser(req).id);
+  /* ───────────── ARCHIVED /case/:id/attachment/:attId ───────────── */
+async archiveAttachment(req: Request, res: Response): Promise<Response> {
+  try {
+    const caseId = Number(req.params.id);
+    const attId = Number(req.params.attId);
+    const user = getUser(req);
 
-      return res
-        .status(HttpStatusCodes.OK.code)
-        .json(
-          buildHttpResponse(
-            HttpStatusCodes.OK.code,
-            MESSAGES.CASE.ATTACHMENT_ARCHIVED,
-            req.path
-          )
-        );
-    } catch (error) {
-      return handleServerError(res, req, error);
-    }
+    // Llama al servicio con caseId, attId y el usuario actual
+    const archived = await casesService.archiveAttachment(caseId, attId, user);
+
+    return res
+      .status(HttpStatusCodes.OK.code)
+      .json(
+        buildHttpResponse(
+          HttpStatusCodes.OK.code,
+          MESSAGES.CASE.ATTACHMENT_ARCHIVED,
+          req.path,
+          archived
+        )
+      );
+  } catch (error) {
+    return handleServerError(res, req, error);
   }
+}
 
-  /* ---------- POST /case/external_client ---------- */
-  async createExternalClient(req: Request, res: Response): Promise<Response> {
-    try {
-      const dto = CreateExternalClientSchema.parse(req.body);
-      const user = getUser(req);
-      const data = await casesService.createExternalClient(dto, user.id);
-
-      return res
-        .status(HttpStatusCodes.CREATED.code)
-        .json(
-          buildHttpResponse(
-            HttpStatusCodes.CREATED.code,
-            "External client created",
-            req.path,
-            data
-          )
-        );
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const err = handleZodError(error, req);
-        return res.status(err.status).json(err);
-      }
-      return handleServerError(res, req, error);
-    }
-  }
-
-  /* ---------- GET /case/categories ---------- */
+  /* ─────────────  GET /case/categories  ───────────── */
   async getCategories(req: Request, res: Response): Promise<Response> {
     try {
       const result = await casesService.getCategories();
@@ -385,8 +382,7 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-
-  /* ---------- GET /case/types ---------- */
+  /* ───────────── GET /case/types───────────── */
   async getStatuses(req: Request, res: Response): Promise<Response> {
     const data = await casesService.getStatuses();
 
@@ -401,8 +397,7 @@ export class CaseController {
         )
       );
   }
-
-  /* ---------- POST /case/:id/message ---------- */
+  /* ─────────────POST /case/:id/message───────────── */
   async sendMessage(req: Request, res: Response) {
     try {
       const id = Number(req.params.id);
@@ -427,8 +422,7 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
-
-  /* ---------- GET /case/:id/history ---------- */
+  /* ─────────────GET /case/:id/history ───────────── */
   async getHistory(req: Request, res: Response) {
     try {
       const id = Number(req.params.id);
@@ -448,4 +442,132 @@ export class CaseController {
       return handleServerError(res, req, error);
     }
   }
+  /* ───────────── POST /case/external_client ───────────── */
+  async createExternalClient(req: Request, res: Response): Promise<Response> {
+    try {
+      const dto = CreateExternalClientSchema.parse(req.body);
+      const user = getUser(req);
+      const data = await casesService.createExternalClient(dto, user.id);
+
+      return res
+        .status(HttpStatusCodes.CREATED.code)
+        .json(
+          buildHttpResponse(
+            HttpStatusCodes.CREATED.code,
+            "External client created",
+            req.path,
+            data
+          )
+        );
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const err = handleZodError(error, req);
+        return res.status(err.status).json(err);
+      }
+      return handleServerError(res, req, error);
+    }
+  }
+  /* ─────────────GET /case/external_clients ───────────── */
+  async listExternalClients(req: Request, res: Response): Promise<Response> {
+    try {
+      const user = getUser(req);
+      const data = await casesService.listExternalClients(user.id);
+
+      return res
+        .status(HttpStatusCodes.OK.code)
+        .json(
+          buildHttpResponse(
+            HttpStatusCodes.OK.code,
+            "External clients fetched",
+            req.path,
+            data
+          )
+        );
+    } catch (error) {
+      return handleServerError(res, req, error);
+    }
+  }
+  /* ───────────── PUT /case/external_clients/:id───────────── */
+  async updateExternalClient(req: Request, res: Response): Promise<Response> {
+    try {
+      const id = Number(req.params.id);
+      const dto = UpdateExternalClientSchema.parse(req.body);
+      const user = getUser(req);
+      const data = await casesService.updateExternalClient(id, dto, user.id);
+
+      return res
+        .status(HttpStatusCodes.OK.code)
+        .json(
+          buildHttpResponse(
+            HttpStatusCodes.OK.code,
+            "External client updated",
+            req.path,
+            data
+          )
+        );
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const err = handleZodError(error, req);
+        return res.status(err.status).json(err);
+      }
+      return handleServerError(res, req, error);
+    }
+  }
+  /* ───────────── PATCH /case/external_clients/:id/archive ───────────── */
+  async archiveExternalClient(req: Request, res: Response): Promise<Response> {
+    try {
+      const id = Number(req.params.id);
+      const user = getUser(req);
+      await casesService.archiveExternalClient(id, user.id);
+
+      return res
+        .status(HttpStatusCodes.OK.code)
+        .json(
+          buildHttpResponse(
+            HttpStatusCodes.OK.code,
+            "External client archived",
+            req.path
+          )
+        );
+    } catch (error) {
+      return handleServerError(res, req, error);
+    }
+  }
+    /* ───────────── GET /cases/external_clients/archived ───────────── */
+
+async listArchivedExternalClients(req: Request, res: Response) {
+  try {
+    const user = getUser(req);
+    const data = await casesService.listArchivedExternalClients(user.id);
+    return res
+      .status(HttpStatusCodes.OK.code)
+      .json(buildHttpResponse(
+        HttpStatusCodes.OK.code,
+        "Archived external clients fetched",
+        req.path,
+        data
+      ));
+  } catch (error) {
+    return handleServerError(res, req, error);
+  }
+}
+    /* ───────────── /cases/external_clients/:id/restore ───────────── */
+async restoreExternalClient(req: Request, res: Response): Promise<Response> {
+  try {
+    const id   = Number(req.params.id);
+    const user = getUser(req);
+    const data = await casesService.restoreExternalClient(id, user.id);
+    return res
+      .status(HttpStatusCodes.OK.code)
+      .json(buildHttpResponse(
+        HttpStatusCodes.OK.code,
+        "External client restored",
+        req.path,
+        data
+      ));
+  } catch (error) {
+    return handleServerError(res, req, error);
+  }
+}
+
 }

--- a/src/modules/case/presentation/routes/case.routes.ts
+++ b/src/modules/case/presentation/routes/case.routes.ts
@@ -1,667 +1,106 @@
+// src/modules/case/presentation/routes/case.routes.ts
 import { Router } from "express";
 import multer from "multer";
 import { authenticateToken } from "../../../../middlewares/authenticate_token";
 import { asyncHandler } from "../../../../middlewares/async_handler";
 import { CaseController } from "../controllers/case.controller";
 
-const caseController = new CaseController();
 const router = Router();
-
-// openapi: 3.0.0
-// info:
-//   title: ArxaTEC Case API
-//   version: 1.0.0
-//   description: API para gestión de casos legales (módulo **case**)
-// servers:
-//   - url: /api/v1/case
-// security:
-//   - bearerAuth: []
-
-// components:
-//   securitySchemes:
-//     bearerAuth:
-//       type: http
-//       scheme: bearer
-//       bearerFormat: JWT
-
-//   schemas:
-//     # ===== DTOs =====
-//     CreateCaseDto:
-//       type: object
-//       required:
-//         - title
-//         - description
-//         - category_id
-//       properties:
-//         title:
-//           type: string
-//           minLength: 5
-//           maxLength: 120
-//         description:
-//           type: string
-//           minLength: 20
-//           maxLength: 2000
-//         category_id:
-//           type: integer
-//         urgency:
-//           type: string
-//           enum: [alta, media, baja]
-//         is_public:
-//           type: boolean
-//         selected_lawyer_id:
-//           type: integer
-//           nullable: true
-//         external_client_id:
-//           type: integer
-//           nullable: true
-
-//     UpdateCaseDto:
-//       type: object
-//       properties:
-//         title:
-//           type: string
-//           minLength: 5
-//           maxLength: 120
-//         description:
-//           type: string
-//           minLength: 20
-//           maxLength: 2000
-//         category_id:
-//           type: integer
-//         urgency:
-//           type: string
-//           enum: [alta, media, baja]
-//         is_public:
-//           type: boolean
-
-//     ChangeCaseStatusDto:
-//       type: object
-//       required: [status_id]
-//       properties:
-//         status_id:
-//           type: integer
-
-//     CreateCaseAttachmentDto:
-//       type: object
-//       required: [service_id, file_key, label, category_id]
-//       properties:
-//         service_id:
-//           type: integer
-//         file_key:
-//           type: string
-//         label:
-//           type: string
-//         description:
-//           type: string
-//           nullable: true
-//         category_id:
-//           type: integer
-
-//     CreateExternalClientDto:
-//       type: object
-//       required: [full_name, phone, dni]
-//       properties:
-//         full_name:
-//           type: string
-//           minLength: 3
-//           maxLength: 100
-//         phone:
-//           type: string
-//           minLength: 6
-//         dni:
-//           type: string
-//           minLength: 4
-//         email:
-//           type: string
-//           format: email
-//           nullable: true
-
-//     CreateCaseMessageDto:
-//       type: object
-//       required: [content]
-//       properties:
-//         content:
-//           type: string
-//           minLength: 1
-
-//     # ===== Entidades / respuestas =====
-//     Case:
-//       type: object
-//       properties:
-//         id: { type: integer }
-//         service_id: { type: integer }
-//         title: { type: string }
-//         description: { type: string }
-//         category_id: { type: integer }
-//         urgency: { type: string }
-//         status_id: { type: integer }
-//         is_public: { type: boolean }
-//         reference_code: { type: string }
-//         created_at: { type: string, format: date-time }
-//         archived: { type: boolean }
-//         # Relaciones anidadas (simplificadas)
-//         service:
-//           type: object
-//           properties:
-//             lawyer_id: { type: integer, nullable: true }
-//             client_id: { type: integer, nullable: true }
-//             external_client_id: { type: integer, nullable: true }
-//         category:
-//           type: object
-//           properties:
-//             id: { type: integer }
-//             name: { type: string }
-//             description: { type: string }
-//         status:
-//           type: object
-//           properties:
-//             id: { type: integer }
-//             name: { type: string }
-//             description: { type: string }
-//         histories:
-//           type: array
-//           items:
-//             $ref: '#/components/schemas/HistoryEntry'
-//         attachments:
-//           type: array
-//           items:
-//             $ref: '#/components/schemas/AttachmentDetail'
-//         messages:
-//           type: array
-//           items:
-//             $ref: '#/components/schemas/Message'
-
-//     CaseList:
-//       type: array
-//       items:
-//         $ref: '#/components/schemas/Case'
-
-//     Category:
-//       type: object
-//       properties:
-//         id: { type: integer }
-//         name: { type: string }
-//         description: { type: string, nullable: true }
-
-//     Status:
-//       type: object
-//       properties:
-//         id: { type: integer }
-//         name: { type: string }
-//         description: { type: string, nullable: true }
-
-//     AttachmentSummary:
-//       type: object
-//       properties:
-//         id: { type: integer }
-//         label: { type: string }
-//         category_id: { type: integer }
-//         uploaded_by: { type: string, enum: [lawyer, client] }
-//         created_at: { type: string, format: date-time }
-//         url:
-//           type: string
-//           description: URL temporal para descarga
-
-//     AttachmentDetail:
-//       allOf:
-//         - $ref: '#/components/schemas/AttachmentSummary'
-//       properties:
-//         file_key: { type: string }
-//         description: { type: string, nullable: true }
-
-//     Message:
-//       type: object
-//       properties:
-//         id: { type: integer }
-//         service_id: { type: integer }
-//         content: { type: string }
-//         sent_by: { type: string, enum: [lawyer, client] }
-//         is_read: { type: boolean }
-//         created_at: { type: string, format: date-time }
-
-//     HistoryEntry:
-//       type: object
-//       properties:
-//         id: { type: integer }
-//         case_id: { type: integer }
-//         changed_by: { type: integer }
-//         field: { type: string }
-//         old_value: { type: string }
-//         new_value: { type: string }
-//         note: { type: string, nullable: true }
-//         created_at: { type: string, format: date-time }
-
-//     ExternalClient:
-//       type: object
-//       properties:
-//         id: { type: integer }
-//         full_name: { type: string }
-//         phone: { type: string }
-//         dni: { type: string }
-//         email: { type: string, nullable: true }
-//         created_at: { type: string, format: date-time }
-
-//   paths:
-//     /:
-//       post:
-//         summary: Crear caso
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         requestBody:
-//           required: true
-//           content:
-//             application/json:
-//               schema:
-//                 $ref: '#/components/schemas/CreateCaseDto'
-//         responses:
-//           '201':
-//             description: Caso creado
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/Case'
-//           '400': { description: Bad Request }
-//           '409': { description: Conflict }
-
-//     /explore:
-//       get:
-//         summary: Explorar casos públicos
-//         tags: [Cases]
-//         parameters:
-//           - in: query
-//             name: category_id
-//             schema:
-//               type: integer
-//           - in: query
-//             name: status_id
-//             schema:
-//               type: integer
-//         responses:
-//           '200':
-//             description: Lista de casos
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/CaseList'
-
-//     /my:
-//       get:
-//         summary: Mis casos (cliente/abogado)
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         responses:
-//           '200':
-//             description: Lista de mis casos
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/CaseList'
-
-//     /{id}:
-//       get:
-//         summary: Detalle de un caso
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             required: true
-//             schema: { type: integer }
-//         responses:
-//           '200':
-//             description: Detalle del caso
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/Case'
-//           '403': { description: Forbidden }
-//           '404': { description: Not Found }
-
-//       put:
-//         summary: Actualizar caso
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//         requestBody:
-//           required: true
-//           content:
-//             application/json:
-//               schema:
-//                 $ref: '#/components/schemas/UpdateCaseDto'
-//         responses:
-//           '200':
-//             description: Caso actualizado
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/Case'
-//           '400': { description: Bad Request }
-//           '403': { description: Forbidden }
-
-//     /{id}/status:
-//       patch:
-//         summary: Cambiar estado de caso
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//         requestBody:
-//           required: true
-//           content:
-//             application/json:
-//               schema:
-//                 $ref: '#/components/schemas/ChangeCaseStatusDto'
-//         responses:
-//           '200':
-//             description: Estado actualizado
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/Case'
-//           '400': { description: Bad Request }
-//           '403': { description: Forbidden }
-//           '409': { description: Conflict }
-
-//     /{id}/archive:
-//       patch:
-//         summary: Archivar caso (soft-delete)
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//         responses:
-//           '200':
-//             description: Caso archivado
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/Case'
-
-//     /{id}/attachment:
-//       post:
-//         summary: Subir adjunto a un caso
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//         requestBody:
-//           required: true
-//           content:
-//             multipart/form-data:
-//               schema:
-//                 type: object
-//                 properties:
-//                   file:
-//                     type: string
-//                     format: binary
-//                   label:
-//                     type: string
-//                   description:
-//                     type: string
-//                   category_id:
-//                     type: integer
-//         responses:
-//           '201':
-//             description: Adjunto creado
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/AttachmentDetail'
-//           '400': { description: Bad Request }
-//           '409': { description: Conflict }
-
-//     /{id}/attachments:
-//       get:
-//         summary: Listar adjuntos de un caso
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//         responses:
-//           '200':
-//             description: Lista de adjuntos
-//             content:
-//               application/json:
-//                 schema:
-//                   type: array
-//                   items:
-//                     $ref: '#/components/schemas/AttachmentSummary'
-
-//     /{id}/attachment/{attId}:
-//       get:
-//         summary: Obtener URL firmada de un adjunto privado
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//           - in: path
-//             name: attId
-//             schema: { type: integer }
-//         responses:
-//           '200':
-//             description: URL generada
-//             content:
-//               application/json:
-//                 schema:
-//                   type: object
-//                   properties:
-//                     url:
-//                       type: string
-
-//       patch:
-//         summary: Archivar (soft-delete) un adjunto
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//           - in: path
-//             name: attId
-//             schema: { type: integer }
-//         responses:
-//           '200':
-//             description: Adjunto archivado
-//             content:
-//               application/json:
-//                 schema:
-//                   type: object
-
-//     /external_client:
-//       post:
-//         summary: Crear cliente externo (solo abogado)
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         requestBody:
-//           required: true
-//           content:
-//             application/json:
-//               schema:
-//                 $ref: '#/components/schemas/CreateExternalClientDto'
-//         responses:
-//           '201':
-//             description: Cliente externo creado
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/ExternalClient'
-
-//     /categories:
-//       get:
-//         summary: Listar categorías de casos
-//         tags: [Cases]
-//         responses:
-//           '200':
-//             description: Categorías obtenidas
-//             content:
-//               application/json:
-//                 schema:
-//                   type: array
-//                   items:
-//                     $ref: '#/components/schemas/Category'
-
-//     /types:
-//       get:
-//         summary: Listar estados (status) de casos
-//         tags: [Cases]
-//         responses:
-//           '200':
-//             description: Estados obtenidos
-//             content:
-//               application/json:
-//                 schema:
-//                   type: array
-//                   items:
-//                     $ref: '#/components/schemas/Status'
-
-//     /{id}/message:
-//       post:
-//         summary: Enviar mensaje interno en un caso
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//         requestBody:
-//           required: true
-//           content:
-//             application/json:
-//               schema:
-//                 $ref: '#/components/schemas/CreateCaseMessageDto'
-//         responses:
-//           '201':
-//             description: Mensaje enviado
-//             content:
-//               application/json:
-//                 schema:
-//                   $ref: '#/components/schemas/Message'
-
-//     /{id}/history:
-//       get:
-//         summary: Historial de cambios de un caso
-//         tags: [Cases]
-//         security: [{ bearerAuth: [] }]
-//         parameters:
-//           - in: path
-//             name: id
-//             schema: { type: integer }
-//         responses:
-//           '200':
-//             description: Historial obtenido
-//             content:
-//               application/json:
-//                 schema:
-//                   type: array
-//                   items:
-//                     $ref: '#/components/schemas/HistoryEntry'
-
 const upload = multer({ storage: multer.memoryStorage() });
+const caseController = new CaseController();
 
-/* -------- PUBLIC CATALOGS -------- */
+// ───────────── PUBLIC CATALOGS ─────────────
+router.get("/categories", asyncHandler(caseController.getCategories.bind(caseController)));
+router.get("/statuses",   asyncHandler(caseController.getStatuses.bind(caseController)));
+
+// ───────────── CASE CREATION ─────────────
+router.post("/", authenticateToken, asyncHandler(caseController.createCase.bind(caseController)));
+// ───────────── CLOSED & ARCHIVED CASES ─────────────
 router.get(
-  "/categories",
-  asyncHandler((req, res) => caseController.getCategories(req, res))
+  "/closed",
+  authenticateToken,
+  asyncHandler((req, res) => caseController.getClosedCases(req, res))
 );
 router.get(
-  "/statuses",
-  asyncHandler((req, res) => caseController.getStatuses(req, res))
+  "/archived",
+  authenticateToken,
+  asyncHandler((req, res) => caseController.getArchivedCases(req, res))
 );
 
-/* -------- CASE CREATION -------- */
+router.patch(
+  "/:id/reopen",
+  authenticateToken,
+  asyncHandler((req, res) => caseController.reopenCase(req, res))
+);
+// ───────────── CLIENT EXTERNAL ─────────────
 router.post(
-  "/",
+  "/external_clients",
   authenticateToken,
-  asyncHandler((req, res) => caseController.createCase(req, res))
-);
-router.post(
-  "/external_client",
-  authenticateToken,
-  asyncHandler((req, res) => caseController.createExternalClient(req, res))
-);
-
-/* -------- CASE READ -------- */
-router.get(
-  "/explore",
-  asyncHandler((req, res) => caseController.exploreCases(req, res))
+  asyncHandler(caseController.createExternalClient.bind(caseController))
 );
 router.get(
-  "/my",
+  "/external_clients",
   authenticateToken,
-  asyncHandler((req, res) => caseController.getMyCases(req, res))
+  asyncHandler(caseController.listExternalClients.bind(caseController))
 );
-router.get(
-  "/:id",
-  authenticateToken,
-  asyncHandler((req, res) => caseController.getCaseById(req, res))
-);
-router.get(
-  "/:id/history",
-  authenticateToken,
-  asyncHandler((req, res) => caseController.getHistory(req, res))
-);
-
-/* -------- CASE UPDATE -------- */
 router.put(
-  "/:id",
+  "/external_clients/:id",
   authenticateToken,
-  asyncHandler((req, res) => caseController.updateCase(req, res))
+  asyncHandler(caseController.updateExternalClient.bind(caseController))
 );
 router.patch(
-  "/:id/status",
+  "/external_clients/:id/archive",
   authenticateToken,
-  asyncHandler((req, res) => caseController.changeStatus(req, res))
+  asyncHandler(caseController.archiveExternalClient.bind(caseController))
 );
-router.patch(
-  "/:id/archive",
+router.get(
+  "/external_clients/archived",
   authenticateToken,
-  asyncHandler((req, res) => caseController.archiveCase(req, res))
+  asyncHandler(caseController.listArchivedExternalClients.bind(caseController))
 );
 
-/* -------- ATTACHMENTS -------- */
+router.patch(
+  "/external_clients/:id/restore",
+  authenticateToken,
+  asyncHandler(caseController.restoreExternalClient.bind(caseController))
+);
+
+// ───────────── CASE READ ─────────────
+router.get("/explore", asyncHandler(caseController.exploreCases.bind(caseController)));
+router.get("/my",      authenticateToken, asyncHandler(caseController.getMyCases.bind(caseController)));
+router.get("/:id/history", authenticateToken, asyncHandler(caseController.getHistory.bind(caseController)));
+router.get("/:id",         authenticateToken, asyncHandler(caseController.getCaseById.bind(caseController)));
+
+// ───────────── CASE UPDATE ─────────────
+router.put("/:id",          authenticateToken, asyncHandler(caseController.updateCase.bind(caseController)));
+router.patch("/:id/status", authenticateToken, asyncHandler(caseController.changeStatus.bind(caseController)));
+router.patch("/:id/archive",authenticateToken, asyncHandler(caseController.archiveCase.bind(caseController)));
+
+// ───────────── ATTACHMENTS ─────────────
 router.post(
   "/:id/attachment",
   authenticateToken,
   upload.fields([{ name: "file", maxCount: 1 }]),
-  asyncHandler((req, res) => caseController.addAttachment(req, res))
+  asyncHandler(caseController.addAttachment.bind(caseController))
 );
 router.get(
   "/:id/attachments",
   authenticateToken,
-  asyncHandler((req, res) => caseController.listAttachments(req, res))
+  asyncHandler(caseController.listAttachments.bind(caseController))
 );
-// GET TEMPORARY SIGNED URL FOR PRIVATE FILE
 router.get(
   "/:id/attachment/:attId",
   authenticateToken,
-  asyncHandler((req, res) => caseController.getAttachmentUrl(req, res))
+  asyncHandler(caseController.getAttachmentUrl.bind(caseController))
 );
-
-// ARCHIVE ATTACHMENT (SOFT DELETE)
 router.patch(
   "/:id/attachment/:attId",
   authenticateToken,
-  asyncHandler((req, res) => caseController.archiveAttachment(req, res))
+  asyncHandler(caseController.archiveAttachment.bind(caseController))
 );
 
-/* -------- INTERNAL MESSAGES -------- */
-router.post(
-  "/:id/message",
-  authenticateToken,
-  asyncHandler((req, res) => caseController.sendMessage(req, res))
-);
+
+// ───────────── INTERNAL MESSAGES ─────────────
+router.post("/:id/message", authenticateToken, asyncHandler(caseController.sendMessage.bind(caseController)));
 
 export default router;

--- a/src/modules/case/presentation/services/cases.service.ts
+++ b/src/modules/case/presentation/services/cases.service.ts
@@ -9,8 +9,11 @@ import type {
   ChangeCaseStatusDto,
   CreateCaseAttachmentDto,
   CreateExternalClientDto,
+  UpdateExternalClientDto,
   CreateCaseMessageDto,
-} from "../../domain/dtos/index";
+} from "../../domain/dtos";
+
+import type { ExternalClientEntity } from "../../domain/entities/external_client.entity";
 
 import { AppError } from "../../../../utils/errors";
 import { HttpStatusCodes } from "../../../../constants/http_status_codes";
@@ -21,9 +24,7 @@ import { io } from "../../../../config/socket";
 type CurrentUser = { id: number; role: "client" | "lawyer" };
 
 export class CasesService {
-  private readonly MAX_OPEN_CLIENT = 5;
-  private readonly MAX_INPROGRESS_LAWYER =
-    Number(process.env.MAX_LAWYER_CASES) || 10;
+  private readonly MAX_INPROGRESS_LAWYER = 5;
 
   private OPEN_STATUS_ID!: number;
 
@@ -45,94 +46,116 @@ export class CasesService {
   }
 
   /* ───────────── CREATE ───────────── */
-  async createCase(
-    dto: CreateCaseDto,
-    user: { id: number; role: "client" | "lawyer" }
-  ) {
-    const statuses = await this.casesRepo.getAllStatuses();
-    if (statuses.length < 4) {
+async createCase(
+  dto: CreateCaseDto,
+  user: { id: number; role: "client" | "lawyer" }
+) {
+  const statuses = await this.casesRepo.getAllStatuses();
+  const initialStatus = statuses[0].id;
+  const takenStatus = statuses[1].id;
+
+  if (user.role === "client") {
+    const maxOpen = 3;
+    const maxTaken = 3;
+
+    const openCount = await this.casesRepo.countClientCasesByStatus({
+      clientId: user.id,
+      status_id: initialStatus,
+    });
+    if (openCount >= maxOpen) {
       throw new AppError(
-        "Debe haber al menos 4 estados configurados.",
-        HttpStatusCodes.INTERNAL_SERVER_ERROR.code
+        `Has alcanzado el límite de ${maxOpen} casos abiertos.`,
+        HttpStatusCodes.CONFLICT.code
       );
     }
-    const initialStatus = statuses[0].id;
-    const takenStatus = statuses[1].id;
 
-    if (user.role === "client") {
-      const openCount = await this.casesRepo
-        .exploreCases({ status_id: initialStatus, is_public: true })
-        .then((r) => r.length);
-      if (openCount >= this.MAX_OPEN_CLIENT) {
-        throw new AppError(
-          MESSAGES.CASE.LIMIT_OPEN_CLIENT,
-          HttpStatusCodes.CONFLICT.code
-        );
-      }
-    }
-
-    let isPublic = dto.is_public ?? true;
-    let lawyerId: number | null | undefined;
-    if (user.role === "client" && dto.selected_lawyer_id) {
-      isPublic = false;
-      lawyerId = dto.selected_lawyer_id;
-    }
-    if (user.role === "lawyer") {
-      isPublic = dto.is_public ?? false;
-      if (!isPublic) lawyerId = user.id;
-    }
-    if (dto.external_client_id && !lawyerId) {
-      const ext = await this.casesRepo.findExternalClientById(
-        dto.external_client_id
+    const takenCount = await this.casesRepo.countClientCasesByStatus({
+      clientId: user.id,
+      status_id: takenStatus,
+    });
+    if (takenCount >= maxTaken) {
+      throw new AppError(
+        `Has alcanzado el límite de ${maxTaken} casos tomados.`,
+        HttpStatusCodes.CONFLICT.code
       );
-      lawyerId = ext?.user_detail_id ?? null;
     }
-
-    const serviceId =
-      dto.service_id ??
-      (
-        await this.casesRepo.createService({
-          type: service_type.case,
-          lawyer: lawyerId ? { connect: { user_id: lawyerId } } : undefined,
-          client:
-            user.role === "client"
-              ? { connect: { user_id: user.id } }
-              : undefined,
-          external_client: dto.external_client_id
-            ? { connect: { id: dto.external_client_id } }
-            : undefined,
-        })
-      ).id;
-
-    const statusIdToUse =
-      lawyerId || user.role === "lawyer" ? takenStatus : initialStatus;
-
-    const created = await this.casesRepo.createCase({
-      service: { connect: { id: serviceId } },
-      title: dto.title,
-      description: dto.description,
-      category: { connect: { id: dto.category_id } },
-      urgency: dto.urgency ?? "media",
-      status: { connect: { id: dto.status_id ?? statusIdToUse } },
-      is_public: isPublic,
-      reference_code: dto.reference_code,
-    });
-
-    await this.notificationService.createNotification({
-      title: MESSAGES.CASE.CREATED_TITLE,
-      description: `Case “${created.title}” created`,
-      type: "info",
-      receiverId: user.id,
-      senderId: user.id,
-      url: `/case/${created.id}`,
-    });
-    io.to(`user:${user.id}`).emit("CASE_CREATED", {
-      id: created.id,
-      title: created.title,
-    });
-
-    return created;
   }
+
+  let isPublic = dto.is_public ?? true;
+  let lawyerId: number | null = null;
+
+  if (user.role === "client" && dto.selected_lawyer_id) {
+    isPublic = false;
+    lawyerId = dto.selected_lawyer_id;
+  } else if (user.role === "lawyer") {
+    isPublic = dto.is_public ?? false;
+    if (!isPublic) lawyerId = user.id;
+  }
+
+
+  if (dto.external_client_id) {
+    const ext = await this.casesRepo.findExternalClientByIdForLawyer(
+      dto.external_client_id,
+      user.id
+    );
+    if (!ext) {
+      throw new AppError(
+        "No puedes usar un cliente externo que no exista o que esté archivado",
+        HttpStatusCodes.FORBIDDEN.code
+      );
+    }
+
+    lawyerId = user.id;
+  }
+
+  const serviceId =
+    dto.service_id ??
+    (
+      await this.casesRepo.createService({
+        type: service_type.case,
+        lawyer: lawyerId ? { connect: { user_id: lawyerId } } : undefined,
+        client:
+          user.role === "client"
+            ? { connect: { user_id: user.id } }
+            : undefined,
+        external_client: dto.external_client_id
+          ? { connect: { id: dto.external_client_id } }
+          : undefined,
+      })
+    ).id;
+
+  const statusIdToUse =
+    dto.selected_lawyer_id || user.role === "lawyer"
+      ? takenStatus
+      : initialStatus;
+
+  const created = await this.casesRepo.createCase({
+    service: { connect: { id: serviceId } },
+    title: dto.title,
+    description: dto.description,
+    category: { connect: { id: dto.category_id } },
+    urgency: dto.urgency ?? "media",
+    status: { connect: { id: dto.status_id ?? statusIdToUse } },
+    is_public: isPublic,
+    reference_code: dto.reference_code,
+  });
+
+  await this.notificationService.createNotification({
+    title: MESSAGES.CASE.CREATED_TITLE,
+    description: `Case “${created.title}” created`,
+    type: "info",
+    receiverId: user.id,
+    senderId: user.id,
+    url: `/case/${created.id}`,
+  });
+  io.to(`user:${user.id}`).emit("CASE_CREATED", {
+    id: created.id,
+    title: created.title,
+  });
+
+  return created;
+}
+
 
   /* ───────────── READ ───────────── */
 
@@ -190,9 +213,30 @@ export class CasesService {
       );
     }
 
+    if (found.archived) {
+      throw new AppError(
+        "No se puede editar un caso archivado.",
+        HttpStatusCodes.CONFLICT.code
+      );
+    }
+
+    const statuses = await this.casesRepo.getAllStatuses();
+    if (statuses.length < 3) {
+      throw new AppError(
+        "Deben existir al menos 3 estados configurados.",
+        HttpStatusCodes.INTERNAL_SERVER_ERROR.code
+      );
+    }
+    const closedId = statuses[statuses.length - 1].id;
+    if (found.status_id === closedId) {
+      throw new AppError(
+        "No se puede editar un caso cerrado.",
+        HttpStatusCodes.CONFLICT.code
+      );
+    }
+
     const clientId = found.service?.client_id ?? null;
     const lawyerId = found.service?.lawyer_id ?? null;
-
     if (
       (user.role === "client" && clientId !== user.id) ||
       (user.role === "lawyer" && lawyerId !== user.id)
@@ -216,12 +260,9 @@ export class CasesService {
 
     return this.casesRepo.updateCase(id, data);
   }
+
   /* ───────────── STATUS ───────────── */
-  async changeStatus(
-    id: number,
-    dto: ChangeCaseStatusDto,
-    user: { id: number; role: "client" | "lawyer" }
-  ) {
+  async changeStatus(id: number, dto: ChangeCaseStatusDto, user: CurrentUser) {
     const found = await this.casesRepo.findCaseById(id);
     if (!found) {
       throw new AppError(
@@ -230,61 +271,73 @@ export class CasesService {
       );
     }
 
+    if (found.archived) {
+      throw new AppError(
+        "No se puede cambiar el estado de un caso archivado.",
+        HttpStatusCodes.CONFLICT.code
+      );
+    }
+
+    const statuses = await this.casesRepo.getAllStatuses();
+    if (statuses.length < 3) {
+      throw new AppError(
+        "Deben haber al menos 3 estados configurados (abierto, tomado, cerrado).",
+        HttpStatusCodes.INTERNAL_SERVER_ERROR.code
+      );
+    }
+    const openId = statuses[0].id;
+    const takenId = statuses[1].id;
+    const closedId = statuses[statuses.length - 1].id;
+
     const currentId = found.status_id;
     const nextId = dto.status_id;
     const clientId = found.service?.client_id ?? null;
     const lawyerId = found.service?.lawyer_id ?? null;
 
-    const statuses = await this.casesRepo.getAllStatuses();
-    if (statuses.length < 4) {
+    if (currentId === openId) {
+      if (nextId !== takenId) {
+        throw new AppError(
+          "Solo se puede pasar de 'Abierto' a 'Tomado'.",
+          HttpStatusCodes.CONFLICT.code
+        );
+      }
+    } else if (currentId === takenId) {
+      if (nextId !== closedId) {
+        throw new AppError(
+          "Solo se puede pasar de 'Tomado' a 'Cerrado'.",
+          HttpStatusCodes.CONFLICT.code
+        );
+      }
+    } else {
       throw new AppError(
-        "Debe haber al menos 4 estados configurados.",
-        HttpStatusCodes.INTERNAL_SERVER_ERROR.code
-      );
-    }
-    const initialId = statuses[0].id; // estado “creado”
-    const takenId = statuses[1].id; // estado “tomado”
-    const penultimateId = statuses[statuses.length - 2].id; // estado “cerrar caso”
-    const finalId = statuses[statuses.length - 1].id; // estado “archivado”
-    const inProgressIds = statuses
-      .slice(1, statuses.length - 2)
-      .map((s) => s.id); // intermedios
-
-    if (nextId <= currentId) {
-      throw new AppError(
-        MESSAGES.CASE.INVALID_STATUS,
+        "No se puede cambiar el estado de un caso ya cerrado.",
         HttpStatusCodes.CONFLICT.code
       );
     }
 
-    if (user.role === "lawyer" && currentId === initialId && !lawyerId) {
-      await this.casesRepo.assignLawyerToService(found.service_id, user.id);
-    }
-
-    if (
-      user.role === "lawyer" &&
-      (nextId === penultimateId || nextId === finalId) &&
-      lawyerId !== user.id
-    ) {
-      throw new AppError(
-        nextId === penultimateId
-          ? MESSAGES.CASE.CLOSE_ONLY_LAWYER
-          : MESSAGES.CASE.ACCESS_DENIED,
-        HttpStatusCodes.FORBIDDEN.code
-      );
-    }
-
-    if (user.role === "lawyer" && inProgressIds.includes(nextId)) {
-      const running = await this.casesRepo.countCasesByLawyer({
+    if (user.role === "lawyer" && currentId === openId && nextId === takenId) {
+      const count = await this.casesRepo.countLawyerCasesByStatus({
         lawyerId: user.id,
-        status_id: nextId,
+        status_id: takenId,
+        excludeExternal: true,
       });
-      if (running >= this.MAX_INPROGRESS_LAWYER) {
+      if (count >= this.MAX_INPROGRESS_LAWYER) {
         throw new AppError(
           MESSAGES.CASE.LIMIT_INPROGRESS_LAWYER,
           HttpStatusCodes.CONFLICT.code
         );
       }
+    }
+
+    if (user.role === "lawyer" && currentId === openId && !lawyerId) {
+      await this.casesRepo.assignLawyerToService(found.service_id, user.id);
+    }
+
+    if (user.role === "lawyer" && nextId === closedId && lawyerId !== user.id) {
+      throw new AppError(
+        MESSAGES.CASE.CLOSE_ONLY_LAWYER,
+        HttpStatusCodes.FORBIDDEN.code
+      );
     }
 
     const updated = await this.casesRepo.changeStatus(id, nextId, user.id);
@@ -304,113 +357,192 @@ export class CasesService {
     return updated;
   }
 
-  /* ───────────── ARCHIVE ───────────── */
-  async archiveCase(
-    id: number,
-    user: { id: number; role: "client" | "lawyer" }
-  ) {
-    const found = await this.casesRepo.findCaseById(id);
-    if (!found) {
-      throw new AppError(
-        MESSAGES.CASE.NOT_FOUND,
-        HttpStatusCodes.NOT_FOUND.code
-      );
-    }
-
-    const clientId = found.service?.client_id ?? null;
-    const lawyerId = found.service?.lawyer_id ?? null;
-
-    if (
-      (user.role === "client" && clientId !== user.id) ||
-      (user.role === "lawyer" && lawyerId !== user.id)
-    ) {
-      throw new AppError(
-        MESSAGES.CASE.ACCESS_DENIED,
-        HttpStatusCodes.FORBIDDEN.code
-      );
-    }
-
-    return this.casesRepo.archiveCase(id, user.id);
+/* ───────────── ARCHIVE ───────────── */
+async archiveCase(id: number, user: CurrentUser) {
+  const found = await this.casesRepo.findCaseById(id);
+  if (!found) {
+    throw new AppError(
+      MESSAGES.CASE.NOT_FOUND,
+      HttpStatusCodes.NOT_FOUND.code
+    );
   }
 
+  const creatorId =
+    found.service.client_id === user.id
+      ? found.service.client_id
+      : found.service.lawyer_id === user.id
+      ? found.service.lawyer_id
+      : null;
+  if (!creatorId) {
+    throw new AppError(
+      "Solo el cliente o abogado originador puede archivar este caso.",
+      HttpStatusCodes.FORBIDDEN.code
+    );
+  }
+
+  if (found.archived) {
+    throw new AppError(
+      "El caso ya está archivado.",
+      HttpStatusCodes.CONFLICT.code
+    );
+  }
+
+  return this.casesRepo.archiveCase(id, user.id);
+}
+
+
   /* ───────────── ATTACHMENTS ───────────── */
-  async addAttachment(
+async addAttachment(
+  caseId: number,
+  dto: CreateCaseAttachmentDto,
+  user: { id: number; role: "client" | "lawyer" }
+) {
+  const found = await this.casesRepo.findCaseById(caseId);
+  if (!found) {
+    throw new AppError(
+      MESSAGES.CASE.NOT_FOUND,
+      HttpStatusCodes.NOT_FOUND.code
+    );
+  }
+
+  if (found.archived) {
+    throw new AppError(
+      "No se pueden agregar adjuntos a un caso archivado.",
+      HttpStatusCodes.CONFLICT.code
+    );
+  }
+
+  const statuses = await this.casesRepo.getAllStatuses();
+  const closedId = statuses[statuses.length - 1].id;
+  if (found.status_id === closedId) {
+    throw new AppError(
+      "No se pueden agregar adjuntos a un caso cerrado.",
+      HttpStatusCodes.CONFLICT.code
+    );
+  }
+
+  const categories = await this.casesRepo.getAllCategories();
+  if (!categories.some((c) => c.id === dto.category_id)) {
+    throw new AppError(
+      "Categoría de adjunto no válida.",
+      HttpStatusCodes.NOT_FOUND.code
+    );
+  }
+
+  const clientId = found.service?.client_id ?? null;
+  const lawyerId = found.service?.lawyer_id ?? null;
+  const isOwner = clientId === user.id || lawyerId === user.id;
+  if (!isOwner) {
+    throw new AppError(
+      MESSAGES.CASE.ACCESS_DENIED,
+      HttpStatusCodes.FORBIDDEN.code
+    );
+  }
+
+  let receiverId: number | null = null;
+  if (user.role === "client") {
+    receiverId = lawyerId;
+  } else {
+    receiverId = clientId;
+    if (!receiverId) {
+      receiverId = null;
+    }
+  }
+
+  try {
+    const created = await this.casesRepo.addAttachment({
+      service:     { connect: { id: found.service_id } },
+      category:    { connect: { id: dto.category_id } },
+      file_key:    dto.file_key,
+      label:       dto.label,
+      description: dto.description,
+      uploaded_by: user.role as actor_type,
+      archived:    false,
+    });
+
+    await this.casesRepo.createCaseHistory({
+      case_id:    caseId,
+      changed_by: user.id,
+      field:      "document",
+      old_value:  "",
+      new_value:  dto.label,
+      note:       "Adjunto agregado por el usuario.",
+    });
+
+    if (receiverId) {
+      await this.notificationService.createNotification({
+        title:       "Nuevo adjunto en el caso",
+        description: `Se ha añadido un archivo: ${dto.label}`,
+        type:        "info",
+        receiverId,
+        url:         `/cases/${caseId}`,
+      });
+    }
+
+    return created;
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      throw new AppError(
+        MESSAGES.CASE.ATTACHMENT_DUPLICATE,
+        HttpStatusCodes.CONFLICT.code
+      );
+    }
+    throw err;
+  }
+}
+
+  async archiveAttachment(
     caseId: number,
-    dto: CreateCaseAttachmentDto,
+    attId: number,
     user: { id: number; role: "client" | "lawyer" }
   ) {
-    const found = await this.casesRepo.findCaseById(caseId);
-    if (!found) {
+    const foundCase = await this.getCaseById(caseId, user);
+
+    const attachment = await this.casesRepo.findAttachmentByServiceIdAndId(
+      attId,
+      caseId
+    );
+    if (!attachment || attachment.archived) {
       throw new AppError(
-        MESSAGES.CASE.NOT_FOUND,
+        "Attachment no encontrado o ya está archivado.",
         HttpStatusCodes.NOT_FOUND.code
       );
     }
 
-    const clientId = found.service?.client_id ?? null;
-    const lawyerId = found.service?.lawyer_id ?? null;
+    const archived = await this.casesRepo.archiveAttachment(attId, user.id);
 
-    const isOwner = clientId === user.id || lawyerId === user.id;
-    if (!isOwner) {
-      throw new AppError(
-        MESSAGES.CASE.ACCESS_DENIED,
-        HttpStatusCodes.FORBIDDEN.code
-      );
-    }
-
-    const receiverId = user.role === "client" ? lawyerId : clientId;
-    if (!receiverId) {
-      throw new AppError(
-        "No se puede notificar porque el caso aún no tiene contraparte asignada.",
-        HttpStatusCodes.BAD_REQUEST.code
-      );
-    }
-
-    try {
-      const created = await this.casesRepo.addAttachment({
-        service: { connect: { id: found.service_id } },
-        category: { connect: { id: dto.category_id } },
-        file_key: dto.file_key,
-        label: dto.label,
-        description: dto.description,
-        uploaded_by: user.role as actor_type,
-        archived: false,
-      });
-
-      await this.casesRepo.createCaseHistory({
-        case_id: caseId,
-        changed_by: user.id,
-        field: "document",
-        old_value: "",
-        new_value: dto.label,
-        note: "Adjunto agregado por el usuario.",
-      });
-
+    const clientId = foundCase.service.client_id;
+    const lawyerId = foundCase.service.lawyer_id;
+    const receiverId = user.id === clientId ? lawyerId : clientId;
+    if (receiverId) {
       await this.notificationService.createNotification({
-        title: "Nuevo adjunto en el caso",
-        description: `Se ha añadido un archivo: ${dto.label}`,
+        title: "Archivo archivado",
+        description: `Se ha archivado el archivo: ${attachment.label}`,
         type: "info",
         receiverId,
         url: `/cases/${caseId}`,
       });
-
-      return created;
-    } catch (err) {
-      if (
-        err instanceof Prisma.PrismaClientKnownRequestError &&
-        err.code === "P2002"
-      ) {
-        throw new AppError(
-          MESSAGES.CASE.ATTACHMENT_DUPLICATE,
-          HttpStatusCodes.CONFLICT.code
-        );
-      }
-      throw err;
     }
+
+    return archived;
   }
 
-  async archiveAttachment(attId: number, userId: number) {
-    const attachment = await this.casesRepo.findAttachmentById(attId);
+  async getAttachmentUrl(
+    caseId: number,
+    attId: number,
+    user: CurrentUser
+  ): Promise<string> {
+    const foundCase = await this.getCaseById(caseId, user);
+    const clientId = foundCase.service.client_id;
+    const lawyerId = foundCase.service.lawyer_id;
+
+    const attachment = await this.casesRepo.findAttachmentByServiceIdAndId(
+      attId,
+      caseId
+    );
     if (!attachment || attachment.archived) {
       throw new AppError(
         "Archivo no encontrado o ya está archivado.",
@@ -418,92 +550,40 @@ export class CasesService {
       );
     }
 
-    const caseInfo = await this.casesRepo.findCaseByServiceId(
-      attachment.service_id
-    );
-    if (!caseInfo) {
-      throw new AppError("Caso no encontrado.", HttpStatusCodes.NOT_FOUND.code);
-    }
-
-    const { client_id, lawyer_id } = caseInfo.service;
-    const isAuthorized = userId === client_id || userId === lawyer_id;
-    if (!isAuthorized) {
+    if (
+      user.role !== attachment.uploaded_by ||
+      (user.id !== clientId && user.id !== lawyerId)
+    ) {
       throw new AppError(
         MESSAGES.CASE.ACCESS_DENIED,
         HttpStatusCodes.FORBIDDEN.code
       );
     }
 
-    await this.casesRepo.updateAttachment(attId, { archived: true });
-
-    await this.casesRepo.createCaseHistory({
-      case_id: caseInfo.id,
-      changed_by: userId,
-      field: "document",
-      old_value: attachment.label,
-      new_value: "archivado",
-      note: "El archivo fue archivado por el usuario.",
-    });
-
-    const receiverId = userId === client_id ? lawyer_id : client_id;
-    if (receiverId) {
-      await this.notificationService.createNotification({
-        title: "Archivo archivado",
-        description: `Se ha archivado el archivo: ${attachment.label}`,
-        type: "info",
-        receiverId,
-        url: `/cases/${caseInfo.id}`,
-      });
-    }
+    return await getSignedUrl(attachment.file_key);
   }
 
-  async getAttachmentUrl(
-    caseId: number,
-    attId: number,
-    user: { id: number; role: "client" | "lawyer" }
-  ) {
-    const found = await this.casesRepo.findCaseById(caseId);
-    if (!found)
-      throw new AppError(
-        MESSAGES.CASE.NOT_FOUND,
-        HttpStatusCodes.NOT_FOUND.code
-      );
 
-    const clientId = found.service?.client_id ?? null;
-    const lawyerId = found.service?.lawyer_id ?? null;
-
-    const att = await this.casesRepo.findAttachmentById(attId);
-    if (!att || att.archived)
-      throw new AppError(
-        "Attachment not found",
-        HttpStatusCodes.NOT_FOUND.code
-      );
-
-    const isUploader =
-      user.role === att.uploaded_by &&
-      (user.id === clientId || user.id === lawyerId);
-    if (!isUploader) {
-      throw new AppError(
-        MESSAGES.CASE.ACCESS_DENIED,
-        HttpStatusCodes.FORBIDDEN.code
-      );
-    }
-
-    const signedUrl = await getSignedUrl(att.file_key);
-
-    return signedUrl;
-  }
   async listAttachments(
     caseId: number,
-    user: { id: number; role: "client" | "lawyer" }
-  ) {
+    user: CurrentUser
+  ): Promise<
+    Array<{
+      id: number;
+      label: string;
+      description: string | null;
+      category_id: number;
+      uploaded_by: "client" | "lawyer";
+      created_at: Date;
+      url: string;
+    }>
+  > {
     await this.getCaseById(caseId, user);
 
-    const atts = await this.casesRepo.findAttachmentsByServiceId(caseId);
+    const attachments = await this.casesRepo.findAttachmentsByServiceId(caseId);
 
-    // 3) Mapear a signed-URL
     return Promise.all(
-      atts.map(async (a) => ({
+      attachments.map(async (a) => ({
         id: a.id,
         label: a.label,
         description: a.description,
@@ -518,18 +598,85 @@ export class CasesService {
   async createExternalClient(
     dto: CreateExternalClientDto,
     userDetailId: number
-  ) {
-    const email = dto.email ?? "";
-
+  ): Promise<ExternalClientEntity> {
     return this.casesRepo.createExternalClient({
       full_name: dto.full_name,
-      email,
+      email: dto.email ?? "",
       phone: dto.phone,
       dni: dto.dni,
       user_detail: { connect: { user_id: userDetailId } },
     });
   }
-  /* ---------- historial ---------- */
+
+  async listExternalClients(
+    userDetailId: number
+  ): Promise<ExternalClientEntity[]> {
+    return this.casesRepo.findExternalClientsByLawyer(userDetailId);
+  }
+
+  async updateExternalClient(
+    id: number,
+    dto: UpdateExternalClientDto,
+    userDetailId: number
+  ): Promise<ExternalClientEntity> {
+    const client = await this.casesRepo.findExternalClientByIdForLawyer(
+      id,
+      userDetailId
+    );
+    if (!client) {
+      throw new AppError(
+        "Cliente externo no encontrado o no te pertenece",
+        HttpStatusCodes.NOT_FOUND.code
+      );
+    }
+    return this.casesRepo.updateExternalClient(id, userDetailId, {
+      full_name: dto.full_name,
+      email: dto.email,
+      phone: dto.phone,
+      dni: dto.dni,
+    });
+  }
+
+  async archiveExternalClient(
+    id: number,
+    userDetailId: number
+  ): Promise<ExternalClientEntity> {
+    const client = await this.casesRepo.findExternalClientByIdForLawyer(
+      id,
+      userDetailId
+    );
+    if (!client) {
+      throw new AppError(
+        "Cliente externo no encontrado o no te pertenece",
+        HttpStatusCodes.NOT_FOUND.code
+      );
+    }
+    return this.casesRepo.archiveExternalClient(id, userDetailId);
+  }
+  async listArchivedExternalClients(
+    userDetailId: number
+  ): Promise<ExternalClientEntity[]> {
+    return this.casesRepo.findArchivedExternalClientsByLawyer(userDetailId);
+  }
+
+  async restoreExternalClient(
+    id: number,
+    userDetailId: number
+  ): Promise<ExternalClientEntity> {
+    const client = await this.casesRepo.findArchivedClientForLawyer(
+      id,
+      userDetailId
+    );
+    if (!client || !client.archived) {
+      throw new AppError(
+        "Cliente externo no encontrado o no está archivado",
+        HttpStatusCodes.NOT_FOUND.code
+      );
+    }
+    return this.casesRepo.restoreExternalClient(id, userDetailId);
+  }
+
+  /* ───────────── HISTORY ───────────── */
   async getHistory(
     caseId: number,
     user: { id: number; role: "client" | "lawyer" }
@@ -557,56 +704,126 @@ export class CasesService {
 
     return this.casesRepo.getCaseHistory(caseId);
   }
+  /* ───────────── CLOSED & ARCHIVED LISTS ───────────── */
+  async listClosedCases(user: CurrentUser) {
+    const statuses = await this.casesRepo.getAllStatuses();
+    const penultimateId = statuses[statuses.length - 2].id;
+    return this.casesRepo.findCasesByUserAndStatus({
+      userId: user.id,
+      role: user.role,
+      status_id: penultimateId,
+    });
+  }
 
-  /* ---------- mensaje interno ---------- */
-  async sendMessage(
-    caseId: number,
-    dto: CreateCaseMessageDto,
-    sender: { id: number; role: "client" | "lawyer" }
-  ) {
-    const found = await this.casesRepo.findCaseById(caseId);
-    if (!found) {
+  async listArchivedCases(user: CurrentUser) {
+    return this.casesRepo.findCasesByUserAndArchived(user.id, user.role);
+  }
+
+  /* ───────────── REOPEN CASE ───────────── */
+  async reopenCase(id: number, user: CurrentUser) {
+    const found = await this.casesRepo.findCaseById(id);
+    if (!found)
       throw new AppError(
         MESSAGES.CASE.NOT_FOUND,
         HttpStatusCodes.NOT_FOUND.code
       );
-    }
 
-    const clientId = found.service?.client_id ?? null;
-    const lawyerId = found.service?.lawyer_id ?? null;
-
-    if (clientId !== sender.id && lawyerId !== sender.id) {
+    const isCreator =
+      found.service.client_id === user.id ||
+      found.service.lawyer_id === user.id;
+    if (!isCreator) {
       throw new AppError(
-        MESSAGES.CASE.ACCESS_DENIED,
+        "Solo el creador del caso puede reabrirlo.",
         HttpStatusCodes.FORBIDDEN.code
       );
     }
 
-    const msg = await this.casesRepo.createMessage({
-      service: { connect: { id: found.service_id } },
-      content: dto.content,
-      sent_by: sender.role as actor_type,
-      is_read: false,
-    });
-
-    const receiverId = sender.id === clientId ? lawyerId : clientId;
-    if (receiverId) {
-      await this.notificationService.createNotification({
-        title: MESSAGES.CASE.MESSAGE_SENT,
-        description: `New message in case “${found.title}”`,
-        type: "info",
-        receiverId,
-        senderId: sender.id,
-        url: `/case/${caseId}`,
-      });
-
-      io.to(`user:${receiverId}`).emit("CASE_NEW_MESSAGE", {
-        caseId,
-        messageId: msg.id,
-      });
+    if (!found.archived) {
+      throw new AppError(
+        "Solo los casos archivados pueden reabrirse.",
+        HttpStatusCodes.CONFLICT.code
+      );
     }
 
-    return msg;
+    const restored = await this.casesRepo.restoreCase(id, user.id);
+    return restored;
   }
+
+  //* ───────────── MESSAGES INTERNAL ───────────── */
+async sendMessage(
+  caseId: number,
+  dto: CreateCaseMessageDto,
+  sender: { id: number; role: "client" | "lawyer" }
+) {
+  // 1) Recuperar el caso
+  const found = await this.casesRepo.findCaseById(caseId);
+  if (!found) {
+    throw new AppError(
+      MESSAGES.CASE.NOT_FOUND,
+      HttpStatusCodes.NOT_FOUND.code
+    );
+  }
+
+  // 2) Bloquear si el caso está archivado
+  if (found.archived) {
+    throw new AppError(
+      "No se pueden enviar mensajes a un caso archivado",
+      HttpStatusCodes.CONFLICT.code
+    );
+  }
+
+  // 3) Obtener IDs de cliente y abogado asignado
+  const clientId = found.service?.client_id ?? null;
+  const lawyerId = found.service?.lawyer_id ?? null;
+
+  // 4) No permitir enviar mensajes si aún no hay abogado asignado
+  if (!lawyerId) {
+    throw new AppError(
+      "No puedes enviar mensajes hasta que un abogado tome el caso",
+      HttpStatusCodes.CONFLICT.code
+    );
+  }
+
+  // 5) Validar que el emisor sea parte de este caso
+  if (sender.role === "client" && clientId !== sender.id) {
+    throw new AppError(
+      MESSAGES.CASE.ACCESS_DENIED,
+      HttpStatusCodes.FORBIDDEN.code
+    );
+  }
+  if (sender.role === "lawyer" && lawyerId !== sender.id) {
+    throw new AppError(
+      MESSAGES.CASE.NOT_ASSIGNED_TO_LAWYER,
+      HttpStatusCodes.FORBIDDEN.code
+    );
+  }
+
+  // 6) Crear el mensaje
+  const msg = await this.casesRepo.createMessage({
+    service: { connect: { id: found.service_id } },
+    content: dto.content,
+    sent_by: sender.role as actor_type,
+    is_read: false,
+  });
+
+  // 7) Notificar al destinatario
+  const receiverId = sender.id === clientId ? lawyerId : clientId;
+  if (receiverId) {
+    await this.notificationService.createNotification({
+      title:      MESSAGES.CASE.MESSAGE_SENT,
+      description:`New message in case “${found.title}”`,
+      type:       "info",
+      receiverId,
+      senderId:   sender.id,
+      url:        `/case/${caseId}`,
+    });
+    io.to(`user:${receiverId}`).emit("CASE_NEW_MESSAGE", {
+      caseId,
+      messageId: msg.id,
+    });
+  }
+
+  return msg;
+}
 
 }


### PR DESCRIPTION

1. Case Limits

- Clients: now enforces a maximum of 3 “open” or “taken” cases (external‐client cases are excluded from this count).
- Lawyers: now enforces a maximum of 5 “taken” cases, excluding those created on behalf of their own external clients.

2. Case Archiving & Closure

- Archiving: only the case’s creator (either the client or the lawyer who took it) can archive. The `archived = true` flag is now set correctly.
- Closure: only the assigned lawyer can transition a case to “Closed.”
- Once a case is “Closed” or “Archived,” it is fully locked (no edits, no status changes, no further messages).
- Adjusted the “Closed → Archived” flow so that moving to “Closed” also flips `archived = true` (and vice versa upon reopening).

New endpoints:
└── GET /cases?status=closed     → list all closed cases
└── GET /cases?status=archived   → list all archived cases
└── PATCH /cases/:id/reopen      → reopen an archived case

3. External Clients

- When you create an external client, it’s now automatically assigned to the lawyer.
- You can `PUT` to edit their data, and `PATCH` to archive (soft-delete) or restore.  
- Fixed a bug where archived external clients could still send messages.
- Available endpoints:
  └── GET  /cases/external_clients                 → list active external clients
  └── GET  /cases/external_clients?status=archived → list archived external clients
  └── PUT  /cases/external_clients/:id             → update an external client’s info
  └── PATCH /cases/external_clients/:id/archive     → archive (soft-delete) an external client
  └── PATCH /cases/external_clients/:id/restore     → restore a previously archived external client

4. Internal Messaging

- Only allowed once a lawyer has taken the case.  
- Block all message‐sending when a case is “Closed” or “Archived.”

Clarified that editing external-client records is now properly gated (only the owning lawyer can edit or archive/restore them).
